### PR TITLE
Avoid useless renaming in zip

### DIFF
--- a/src/Support/MediaStream.php
+++ b/src/Support/MediaStream.php
@@ -102,7 +102,7 @@ class MediaStream implements Responsable
                 break;
             }
 
-            if ($media->file_name === $fileName) {
+            if ($this->getZipFileNamePrefix($mediaItems, $index).$media->file_name === $this->getZipFileNamePrefix($mediaItems, $currentIndex).$fileName) {
                 $fileNameCount++;
             }
         }


### PR DESCRIPTION
Using "zip_filename_prefix" custom property, a zip file can contain files with same name but not in the same directory, so rename it is useless.